### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -37,6 +37,8 @@
 # refer to https://github.com/microsoft/github-actions-for-desktop-apps
 
 name: .NET Core Desktop
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/vscodium/security/code-scanning/31](https://github.com/ReuelAlbert-Dev/vscodium/security/code-scanning/31)

To fix the problem, explicitly specify a `permissions` block at the workflow or job level. Since there's only one job (`build`) and no job-specific permissions are required, it's best to add the `permissions` block just below the workflow name (after line 39). The minimal recommended permission is `contents: read`, which allows the job to check out code but prevents unnecessary write permissions for the GITHUB_TOKEN. If additional permissions (like `pull-requests: write`) were needed, they could be added, but this workflow only checks out code and uploads artifacts, so `contents: read` suffices.

Edit the file `.github/workflows/dotnet-desktop.yml` and insert:

```yaml
permissions:
  contents: read
```

immediately after the `name:` field, before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
