### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stable-spearhead.yml
+++ b/.github/workflows/stable-spearhead.yml
@@ -1,4 +1,6 @@
 name: stable-spearhead
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/vscodium/security/code-scanning/32](https://github.com/ReuelAlbert-Dev/vscodium/security/code-scanning/32)

The best way to fix this problem is to explicitly add a `permissions` block to the workflow YAML, restricting the `GITHUB_TOKEN` to the least privilege required. In this context, `contents: read` is the recommended minimal permission, unless writing is explicitly required by the workflow (none is clearly shown here, though the release process may need more).  
This can be done by adding a `permissions:` block at the top level (recommended: applies to all jobs unless overridden). To minimize risk and follow the prompt's advice, add this at the root (above `jobs:`).

Required changes:
- Add the following block after the workflow name and before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
No additional imports or methods are needed; only the YAML needs editing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
